### PR TITLE
Add include guard; inline function

### DIFF
--- a/computer_on.h
+++ b/computer_on.h
@@ -1,3 +1,8 @@
-int computer_on() {
+#ifndef _LIBCOMPUTERON_COMPUTER_ON_H_
+#define _LIBCOMPUTERON_COMPUTER_ON_H_
+
+inline int computer_on() {
 	return 1;
 }
+
+#endif // _LIBCOMPUTERON_COMPUTER_ON_H_


### PR DESCRIPTION
For such an important library, I feel that it would be irresponsible not to have a proper include guard to avoid linker errors. Additionally, the function should be inlined to avoid violations of the ODR.